### PR TITLE
declared argument type to eliminate build warning

### DIFF
--- a/src/starling/extensions/lighting/LightEffect.as
+++ b/src/starling/extensions/lighting/LightEffect.as
@@ -334,7 +334,7 @@ class Light
     public var color:uint;
     public var type:String;
 
-    public function Light(color:uint=0xffffff, type="point")
+    public function Light(color:uint=0xffffff, type:String="point")
     {
         x = y = z = 0.0;
         this.color = color;


### PR DESCRIPTION
Specified the type argument of the Light function as being String, to eliminate the warning produced during build.